### PR TITLE
Compatibility with 'Sensible Entrance Points' from Tweaks Anthology

### DIFF
--- a/bp-bgt-worldmap/lib/compat/bg2_tweaks/3220.tpa
+++ b/bp-bgt-worldmap/lib/compat/bg2_tweaks/3220.tpa
@@ -1,29 +1,19 @@
-ACTION_DEFINE_ASSOCIATIVE_ARRAY entry BEGIN
-  AR3300 => CDEastExit // beregost
-  AR1400 => CDSouthExit // nfai
-  AR0400 => CDSouthExit // zfarm
-  AR3100 => CDSouthExit // shipw
-  AR3600 => CDNorthExit // lhouse
-END
-
-ACTION_DEFINE_ASSOCIATIVE_ARRAY default_entry BEGIN
-  AR3300 => 1 // beregost
-  AR1400 => 4 // nfai
-  AR0400 => 2 // zfarm
-  AR3100 => 4 // shipw
-  AR3600 => 4 // lhouse
-END
+// I am 1000% sure there are more elegant ways to do this, but this works
+// only using tutu area refs as no changes are needed on bgt
 
 ACTION_PHP_EACH fl#DEF AS e => def BEGIN
   OUTER_SPRINT src "%e_0%"
   OUTER_SPRINT node "%e_1%"
   OUTER_SPRINT target "%e_2%"
-  ACTION_FOR_EACH area IN AR3300 AR1400 AR 0400 AR3100 AR3600 BEGIN
-    ACTION_IF "%target%" STR_EQ "%area%" AND
-              def = $default_entry("%area%") AND
-              !VARIABLE_IS_SET $fl#ENTRY("%src%" "%node%" "%target%")
-    BEGIN
-      OUTER_SPRINT $fl#ENTRY("%src%" "%node%" "%target%") $entry("%area%")
-    END
-  END
+  ACTION_IF (("%target%" STR_EQ "fw3300") AND (def = 2) AND !VARIABLE_IS_SET $fl#ENTRY("%src%" "%node%" "%target%")) BEGIN
+    OUTER_SPRINT $fl#ENTRY("%src%" "%node%" "%target%") ~CDEastExit~
+  END  
+  ACTION_IF ((("%target%" STR_EQ "fw0400") AND (def = 4) AND !VARIABLE_IS_SET $fl#ENTRY("%src%" "%node%" "%target%")) OR 
+             (("%target%" STR_EQ "fw1400") AND (def = 4) AND !VARIABLE_IS_SET $fl#ENTRY("%src%" "%node%" "%target%")) OR 
+             (("%target%" STR_EQ "fw3100") AND (def = 4) AND !VARIABLE_IS_SET $fl#ENTRY("%src%" "%node%" "%target%"))) BEGIN
+    OUTER_SPRINT $fl#ENTRY("%src%" "%node%" "%target%") ~CDSouthExit~
+  END  
+  ACTION_IF (("%target%" STR_EQ "fw3600") AND (def = 1) AND !VARIABLE_IS_SET $fl#ENTRY("%src%" "%node%" "%target%")) BEGIN
+    OUTER_SPRINT $fl#ENTRY("%src%" "%node%" "%target%") ~CDNorthExit~
+  END  
 END


### PR DESCRIPTION
On Tutu, the new world map was overwriting the new entrance names added by Tweaks Anthology. If this component from Anthology is detected, the links will be updated to the new Anthology entrance names, removing the incompatibility and ensuring both work as intended.

Since BGT already had defined entrance names, no actual compatibility code was required and it has been removed. The BGT framework was not used as a template for the Tutu compatibility code--the arrays were overwriting themselves with non-unique keys.